### PR TITLE
Remove resizing of tdBattlePetScript Auto button to avoid text overlap.

### DIFF
--- a/OtherAddons.lua
+++ b/OtherAddons.lua
@@ -62,7 +62,6 @@ end
 A.otherAddons.tdBattlePetScript = {}
 function A.otherAddons.tdBattlePetScript:Setup()
     if tdBattlePetScriptAutoButton then
-        tdBattlePetScriptAutoButton:SetWidth(60)
         if (C_PetBattles.IsPlayerNPC(LE_BATTLE_PET_ENEMY)) then
             PetBattleFrame.BottomFrame.TurnTimer.SkipButton:SetPoint("CENTER", -30, 0)
         end


### PR DESCRIPTION
Since the Pet Battle Script addon now uses the term "Autobattle" instead of "Auto" for the auto battle button, Annene will resize the button down so the text extends past the button region:
![Screenshot 2023-05-22 083946](https://github.com/Urtgard/Annene/assets/42030/fd069930-3787-4f79-b142-8f277138f052)

This pull request just removes the button resizing to let the button Autobattle text fit within the button as normal:
![Screenshot 2023-05-22 083752](https://github.com/Urtgard/Annene/assets/42030/4c8c5117-5f65-41bf-bcba-1a702a469a3d)


This does make the buttons non-symmetrical, but I believe that's a better trade-off than a broken-looking button.
